### PR TITLE
Set up gallery theme fonts and colors

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,11 +1,16 @@
-import { Footer, Navigation } from "components";
 import type { AppProps } from "next/app";
+
+import { Footer, Navigation } from "components";
+import FontProvider from "utils/FontProvider";
+
 import "styles/bootstrap.scss";
 import "styles/globals.css";
+import "styles/hackuci.scss";
 
 export default function App({ Component, pageProps }: AppProps) {
 	return (
 		<>
+			<FontProvider />
 			<Navigation />
 			<main>
 				<Component {...pageProps} />

--- a/src/styles/_gallery-theme.scss
+++ b/src/styles/_gallery-theme.scss
@@ -1,6 +1,14 @@
 /* colors for 2023 gallery theme */
-$orange: #d47a29;
+$white: #fff;
+
+$orange: #f09932;
 $light-orange: #fdc27f;
 $dark-orange: #9e3b10;
 $dark-brown: #50200b;
-$navy-blue: #1a436a;
+$navy-blue: #0f2f4e;
+
+$midnight-blue: #041337;
+$deep-blue: #0e2637;
+
+$wild-orange: #ce702d;
+$dark-wild-orange: #aa5315;

--- a/src/styles/_gallery-theme.scss
+++ b/src/styles/_gallery-theme.scss
@@ -1,0 +1,6 @@
+/* colors for 2023 gallery theme */
+$orange: #d47a29;
+$light-orange: #fdc27f;
+$dark-orange: #9e3b10;
+$dark-brown: #50200b;
+$navy-blue: #1a436a;

--- a/src/styles/_hackuci-overrides.scss
+++ b/src/styles/_hackuci-overrides.scss
@@ -1,0 +1,7 @@
+/* Overrides to apply to default values of Bootstrap variables */
+$font-family-base: var(--next-font-open-sans);
+$font-size-base: 1.125rem;
+$headings-font-weight: 700;
+$h1-font-size: 6rem;
+$h2-font-size: 4rem;
+$h3-font-size: 2rem;

--- a/src/styles/hackuci.scss
+++ b/src/styles/hackuci.scss
@@ -1,10 +1,14 @@
-h1,
-.h1 {
-	font-family: var(--next-font-merriweather);
-	font-weight: 700;
+@use "utils/bootstrap";
+
+section.container {
+	// responsive padding
+	@include bootstrap.padding-top(10rem);
+	@include bootstrap.padding-bottom(10rem);
 }
 
+h1,
+.h1,
 h2,
 .h2 {
-	font-weight: 700;
+	font-family: var(--next-font-merriweather);
 }

--- a/src/styles/hackuci.scss
+++ b/src/styles/hackuci.scss
@@ -1,0 +1,10 @@
+h1,
+.h1 {
+	font-family: var(--next-font-merriweather);
+	font-weight: 700;
+}
+
+h2,
+.h2 {
+	font-weight: 700;
+}

--- a/src/utils/FontProvider.tsx
+++ b/src/utils/FontProvider.tsx
@@ -1,0 +1,28 @@
+import { Merriweather, Open_Sans } from "@next/font/google";
+
+const merriweather = Merriweather({
+	weight: ["700"],
+	subsets: ["latin"],
+	display: "swap",
+});
+
+const open_sans = Open_Sans({
+	weight: ["400", "500", "600", "700"],
+	subsets: ["latin"],
+	display: "swap",
+});
+
+function FontProvider() {
+	return (
+		<style jsx global>
+			{`
+				:root {
+					--next-font-open-sans: ${open_sans.style.fontFamily};
+					--next-font-merriweather: ${merriweather.style.fontFamily};
+				}
+			`}
+		</style>
+	);
+}
+
+export default FontProvider;

--- a/src/utils/_bootstrap.scss
+++ b/src/utils/_bootstrap.scss
@@ -3,7 +3,10 @@
 @import "~bootstrap/scss/functions";
 
 /* variable overrides */
-// <put overrides here>
+$font-family-base: var(--next-font-open-sans);
+$font-size-base: 1.125rem;
+$h1-font-size: 6rem;
+$h2-font-size: 4rem;
 
 @import "~bootstrap/scss/variables";
 

--- a/src/utils/_bootstrap.scss
+++ b/src/utils/_bootstrap.scss
@@ -3,10 +3,7 @@
 @import "~bootstrap/scss/functions";
 
 /* variable overrides */
-$font-family-base: var(--next-font-open-sans);
-$font-size-base: 1.125rem;
-$h1-font-size: 6rem;
-$h2-font-size: 4rem;
+@import "styles/hackuci-overrides";
 
 @import "~bootstrap/scss/variables";
 

--- a/src/views/home/Home.module.scss
+++ b/src/views/home/Home.module.scss
@@ -1,0 +1,10 @@
+@import "styles/gallery-theme";
+
+.home {
+	color: $white;
+	background-color: $dark-brown;
+
+	.faqBackground {
+		background-color: $wild-orange;
+	}
+}

--- a/src/views/home/Home.tsx
+++ b/src/views/home/Home.tsx
@@ -1,10 +1,17 @@
+import Faq from "./sections/Faq";
 import Landing from "./sections/Landing";
+import Support from "./sections/Support";
+
+import styles from "./Home.module.scss";
 
 function Home() {
 	return (
-		<div>
-			Home
+		<div className={styles.home}>
 			<Landing />
+			<Support />
+			<div className={styles.faqBackground}>
+				<Faq />
+			</div>
 		</div>
 	);
 }

--- a/src/views/home/sections/Faq.tsx
+++ b/src/views/home/sections/Faq.tsx
@@ -1,0 +1,12 @@
+import Container from "react-bootstrap/Container";
+
+function Faq() {
+	return (
+		<Container as="section">
+			<h2>FAQ</h2>
+			<p>Lorem ipsum dolor sit amet consectetur, adipisicing elit.</p>
+		</Container>
+	);
+}
+
+export default Faq;

--- a/src/views/home/sections/Landing.tsx
+++ b/src/views/home/sections/Landing.tsx
@@ -1,5 +1,10 @@
 function Landing() {
-	return <div>Landing</div>;
+	return (
+		<div>
+			<h1>HackUCI</h1>
+			<p>Lorem ipsum dolor, sit amet consectetur adipisicing elit.</p>
+		</div>
+	);
 }
 
 export default Landing;

--- a/src/views/home/sections/Support.tsx
+++ b/src/views/home/sections/Support.tsx
@@ -1,0 +1,14 @@
+import Container from "react-bootstrap/Container";
+
+function Support() {
+	return (
+		<Container as="section">
+			<h2>Support</h2>
+			<p>Lorem ipsum dolor, sit amet consectetur adipisicing elit.</p>
+			<h3>Apply to be a mentor</h3>
+			<p>Lorem ipsum dolor, sit amet consectetur adipisicing elit.</p>
+		</Container>
+	);
+}
+
+export default Support;


### PR DESCRIPTION
- Add Open Sans and Merriweather through @next/font
  - Create global styles with CSS custom properties for typeface names to be consumed by Bootstrap variable overrides
- Add main colors used by gallery theme
- Create placeholder sections to visually check theme