### PR TITLE
Restrict login to .edu emails

### DIFF
--- a/src/api/routers/user.py
+++ b/src/api/routers/user.py
@@ -3,7 +3,7 @@ from logging import getLogger
 
 from fastapi import APIRouter, Depends, Form, HTTPException, UploadFile, status
 from fastapi.responses import RedirectResponse
-from pydantic import EmailError, EmailStr
+from pydantic import EmailStr
 
 from models.ApplicationData import ProcessedApplicationData, RawApplicationData
 from models.User import User
@@ -22,13 +22,11 @@ def _uci_email(email: str) -> bool:
 
 
 @router.post("/login")
-async def login(email: str = Form()) -> RedirectResponse:
-    try:
-        if not email.endswith(".edu"):
-            raise EmailError()
-        EmailStr.validate(email)
-    except EmailError:
-        raise HTTPException(400, "Invalid email address")
+async def login(email: EmailStr = Form()) -> RedirectResponse:
+    if not email.endswith(".edu"):
+        raise HTTPException(
+            status.HTTP_403_FORBIDDEN, "Only .edu emails are allowed to login"
+        )
 
     if _uci_email(email):
         # redirect user to UCI SSO login endpoint, changing to GET method

--- a/src/api/routers/user.py
+++ b/src/api/routers/user.py
@@ -24,6 +24,8 @@ def _uci_email(email: str) -> bool:
 @router.post("/login")
 async def login(email: str = Form()) -> RedirectResponse:
     try:
+        if not email.endswith(".edu"):
+            raise EmailError()
         EmailStr.validate(email)
     except EmailError:
         raise HTTPException(400, "Invalid email address")

--- a/src/views/login/components/LoginForm.tsx
+++ b/src/views/login/components/LoginForm.tsx
@@ -6,6 +6,7 @@ import Form from "react-bootstrap/Form";
 import { ValidatingForm } from "components";
 
 const EMAIL_REGEX = /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/;
+const EDU_REGEX = /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.edu)+$/;
 const LOGIN_PATH = "/api/user/login";
 
 function LoginForm() {
@@ -18,7 +19,7 @@ function LoginForm() {
 				<Form.Control
 					as="input"
 					type="email"
-					pattern={EMAIL_REGEX.source}
+					pattern={EDU_REGEX.source}
 					required
 					name="email"
 					placeholder="Enter email"
@@ -29,7 +30,9 @@ function LoginForm() {
 					aria-describedby="email-description"
 				/>
 				<Form.Control.Feedback type="invalid">
-					Sorry, that email address is invalid.
+					{EMAIL_REGEX.exec(emailInput) !== null
+						? 'Sorry, only emails that end in ".edu" are allowed to log in.'
+						: "Sorry, that email address is invalid."}
 				</Form.Control.Feedback>
 				<Form.Text id="email-description" muted>
 					UCI students will log in with UCI SSO.

--- a/src/views/login/components/LoginForm.tsx
+++ b/src/views/login/components/LoginForm.tsx
@@ -6,7 +6,7 @@ import Form from "react-bootstrap/Form";
 import { ValidatingForm } from "components";
 
 const EMAIL_REGEX = /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/;
-const EDU_REGEX = /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.edu)+$/;
+const EDU_REGEX = /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.edu)$/;
 const LOGIN_PATH = "/api/user/login";
 
 function LoginForm() {
@@ -30,7 +30,7 @@ function LoginForm() {
 					aria-describedby="email-description"
 				/>
 				<Form.Control.Feedback type="invalid">
-					{EMAIL_REGEX.exec(emailInput) !== null
+					{EMAIL_REGEX.test(emailInput)
 						? 'Sorry, only emails that end in ".edu" are allowed to log in.'
 						: "Sorry, that email address is invalid."}
 				</Form.Control.Feedback>


### PR DESCRIPTION
- Update `LoginForm.tsx`:
    - Add a new regular expression for detecting `.edu` emails. If the email matches with the original regular expression but not the `.edu` one, then a different error message will be shown instead of "Sorry, this email is invalid".
- Update `user.py`:
    - Raise `EmailError` if the email provided does not end with `.edu`.