### PR TITLE
Implement Carousel Gallery as part of Museum Room design

### DIFF
--- a/src/components/CarouselGallery/CarouselGallery.module.scss
+++ b/src/components/CarouselGallery/CarouselGallery.module.scss
@@ -13,6 +13,9 @@
 		}
 	}
 
+	position: absolute;
+	width: 100%;
+
 	$r: 90vh;
 	perspective: 1.3 * $r;
 
@@ -23,9 +26,11 @@
 		align-items: center;
 		justify-content: center;
 
-		transform-style: preserve-3d;
-		transform-origin: center center $r;
-		animation: $tt rotate-carousel infinite linear;
+		&.rotating {
+			transform-style: preserve-3d;
+			transform-origin: center center $r;
+			animation: $tt rotate-carousel infinite linear;
+		}
 
 		.painting {
 			height: 30vh;

--- a/src/components/CarouselGallery/CarouselGallery.module.scss
+++ b/src/components/CarouselGallery/CarouselGallery.module.scss
@@ -1,0 +1,60 @@
+@import "styles/gallery-theme";
+
+.galleryBackground {
+	$n: 8;
+	--o: 0;
+	$tt: 20s;
+	$nk: 100;
+
+	@keyframes rotate {
+		@for $i from 0 through $nk {
+			#{$i / $nk * 100%} {
+				--o: #{-$n / 2 + $n * ($i / $nk)};
+			}
+		}
+	}
+
+	.paintings {
+		height: 100vh;
+		animation: $tt rotate infinite linear;
+
+		display: flex;
+		align-items: center;
+		justify-content: center;
+
+		$vd: 60rem;
+		perspective: $vd;
+		perspective-origin: center;
+
+		$r: 50rem;
+
+		.painting {
+			width: 20rem;
+			height: 20rem;
+			position: absolute;
+
+			background-image: linear-gradient(55.62deg, $wild-orange, $midnight-blue);
+
+			&:nth-child(2n + 1) {
+				width: 15rem;
+			}
+
+			@for $i from 1 through $n {
+				&:nth-child(#{$i}) {
+					$k: $i - $n / 2;
+					$h: calc((#{$k} - var(--o)) * #{360 / $n});
+					$alpha: calc(
+						#{$h} * 1deg - 360deg * Round(down, calc(#{$h} / 360), 1) + 180deg
+					);
+
+					$x: calc($r * sin($alpha));
+					$ry: calc(-1 * $alpha);
+					$dz: calc($r * (1 - cos($alpha)));
+					transform: translateZ($dz) translateX($x) rotateY($ry);
+				}
+			}
+
+			transition: $tt/$nk transform linear;
+		}
+	}
+}

--- a/src/components/CarouselGallery/CarouselGallery.module.scss
+++ b/src/components/CarouselGallery/CarouselGallery.module.scss
@@ -1,60 +1,59 @@
 @import "styles/gallery-theme";
 
-.galleryBackground {
-	$n: 8;
-	--o: 0;
-	$tt: 20s;
-	$nk: 100;
+.carouselGallery {
+	$n: 12;
+	$tt: 120s;
 
-	@keyframes rotate {
-		@for $i from 0 through $nk {
-			#{$i / $nk * 100%} {
-				--o: #{-$n / 2 + $n * ($i / $nk)};
-			}
+	@keyframes rotate-carousel {
+		from {
+			transform: rotateY(0deg);
+		}
+		to {
+			transform: rotateY(360deg);
 		}
 	}
 
+	$r: 90vh;
+	perspective: 1.3 * $r;
+
 	.paintings {
-		height: 100vh;
-		animation: $tt rotate infinite linear;
+		height: 80vh;
 
 		display: flex;
 		align-items: center;
 		justify-content: center;
 
-		$vd: 60rem;
-		perspective: $vd;
-		perspective-origin: center;
-
-		$r: 50rem;
+		transform-style: preserve-3d;
+		transform-origin: center center $r;
+		animation: $tt rotate-carousel infinite linear;
 
 		.painting {
-			width: 20rem;
-			height: 20rem;
+			height: 30vh;
+			aspect-ratio: 3/2;
 			position: absolute;
 
 			background-image: linear-gradient(55.62deg, $wild-orange, $midnight-blue);
 
 			&:nth-child(2n + 1) {
-				width: 15rem;
+				aspect-ratio: 4/5;
 			}
 
 			@for $i from 1 through $n {
 				&:nth-child(#{$i}) {
-					$k: $i - $n / 2;
-					$h: calc((#{$k} - var(--o)) * #{360 / $n});
-					$alpha: calc(
-						#{$h} * 1deg - 360deg * Round(down, calc(#{$h} / 360), 1) + 180deg
-					);
-
-					$x: calc($r * sin($alpha));
-					$ry: calc(-1 * $alpha);
-					$dz: calc($r * (1 - cos($alpha)));
-					transform: translateZ($dz) translateX($x) rotateY($ry);
+					$ry: -$i * 360deg / $n;
+					$dz: -$r;
+					transform: translateZ(-$dz) rotateY($ry) translateZ($dz);
 				}
 			}
+		}
 
-			transition: $tt/$nk transform linear;
+		.paintingNumber {
+			display: flex;
+			flex-direction: column;
+			text-align: center;
+			justify-content: center;
+			font-size: 8rem;
+			font-weight: 700;
 		}
 	}
 }

--- a/src/components/CarouselGallery/CarouselGallery.module.scss
+++ b/src/components/CarouselGallery/CarouselGallery.module.scss
@@ -19,6 +19,9 @@
 	perspective: inherit;
 	perspective-origin: inherit;
 
+	/* for certain versions of Safari, perspective origin is shifted incorrectly */
+	transform-origin: center center (-$offset/2.5);
+
 	.paintings {
 		height: 100%;
 
@@ -26,9 +29,9 @@
 		align-items: center;
 		justify-content: center;
 
+		transform-style: preserve-3d; /* needed even when not rotating for Chrome */
+		transform-origin: 50% 50% $offset; /* needed even when not rotating for Safari */
 		&.rotating {
-			transform-style: preserve-3d;
-			transform-origin: center center $offset;
 			animation: $tt rotate-carousel infinite linear;
 		}
 

--- a/src/components/CarouselGallery/CarouselGallery.module.scss
+++ b/src/components/CarouselGallery/CarouselGallery.module.scss
@@ -1,3 +1,4 @@
+@use "layouts/MuseumRoom.module";
 @import "styles/gallery-theme";
 
 .carouselGallery {
@@ -13,14 +14,13 @@
 		}
 	}
 
-	position: absolute;
-	width: 100%;
-
-	$r: 90vh;
-	perspective: 1.3 * $r;
+	$r: MuseumRoom.$r;
+	$offset: MuseumRoom.$offset;
+	perspective: inherit;
+	perspective-origin: inherit;
 
 	.paintings {
-		height: 80vh;
+		height: 100%;
 
 		display: flex;
 		align-items: center;
@@ -28,7 +28,7 @@
 
 		&.rotating {
 			transform-style: preserve-3d;
-			transform-origin: center center $r;
+			transform-origin: center center $offset;
 			animation: $tt rotate-carousel infinite linear;
 		}
 
@@ -47,7 +47,7 @@
 				&:nth-child(#{$i}) {
 					$ry: -$i * 360deg / $n;
 					$dz: -$r;
-					transform: translateZ(-$dz) rotateY($ry) translateZ($dz);
+					transform: translateZ($offset) rotateY($ry) translateZ($dz);
 				}
 			}
 		}

--- a/src/components/CarouselGallery/CarouselGallery.tsx
+++ b/src/components/CarouselGallery/CarouselGallery.tsx
@@ -1,0 +1,19 @@
+import styles from "./CarouselGallery.module.scss";
+
+function CarouselGallery() {
+	return (
+		<div className={styles.galleryBackground}>
+			<div className={styles.paintings}>
+				{Array(8)
+					.fill(0)
+					.map((_, i) => (
+						<div key={i} className={styles.painting}>
+							painting {i + 1}
+						</div>
+					))}
+			</div>
+		</div>
+	);
+}
+
+export default CarouselGallery;

--- a/src/components/CarouselGallery/CarouselGallery.tsx
+++ b/src/components/CarouselGallery/CarouselGallery.tsx
@@ -2,13 +2,16 @@ import styles from "./CarouselGallery.module.scss";
 
 function CarouselGallery() {
 	return (
-		<div className={styles.galleryBackground}>
+		<div className={styles.carouselGallery}>
 			<div className={styles.paintings}>
-				{Array(8)
+				{Array(12)
 					.fill(0)
 					.map((_, i) => (
-						<div key={i} className={styles.painting}>
-							painting {i + 1}
+						<div
+							key={i}
+							className={[styles.painting, styles.paintingNumber].join(" ")}
+						>
+							{i + 1}
 						</div>
 					))}
 			</div>

--- a/src/components/CarouselGallery/CarouselGallery.tsx
+++ b/src/components/CarouselGallery/CarouselGallery.tsx
@@ -1,9 +1,15 @@
 import styles from "./CarouselGallery.module.scss";
 
-function CarouselGallery() {
+interface CarouselGalleryProps {
+	rotating: boolean;
+}
+
+function CarouselGallery({ rotating }: CarouselGalleryProps) {
 	return (
 		<div className={styles.carouselGallery}>
-			<div className={styles.paintings}>
+			<div
+				className={[styles.paintings, rotating && styles.rotating].join(" ")}
+			>
 				{Array(12)
 					.fill(0)
 					.map((_, i) => (

--- a/src/components/Navigation/Navigation.module.scss
+++ b/src/components/Navigation/Navigation.module.scss
@@ -3,8 +3,9 @@
 
 .navbar {
 	$underline-size: 4px;
+	z-index: 10;
 
-	background-color: $wild-orange;
+	background-color: transparent;
 	font-weight: 700;
 
 	:global {

--- a/src/components/index.js
+++ b/src/components/index.js
@@ -1,3 +1,4 @@
+export { default as CarouselGallery } from "./CarouselGallery/CarouselGallery";
 export { default as Footer } from "./Footer/Footer";
 export { default as Navigation } from "./Navigation/Navigation";
 export { default as ValidatingForm } from "./ValidatingForm/ValidatingForm";

--- a/src/layouts/MuseumRoom.module.scss
+++ b/src/layouts/MuseumRoom.module.scss
@@ -1,0 +1,72 @@
+@import "styles/gallery-theme";
+
+$r: 90vh;
+// z-coordinate of center of carousel
+$offset: $r / 1.8;
+
+@mixin circle($radius) {
+	width: 2 * $radius;
+	height: 2 * $radius;
+	border-radius: $radius;
+}
+
+.museumRoom {
+	// start from top of page by excluding at least navbar height
+	margin-top: -66px;
+
+	width: 100%;
+	$room-height: 60vh;
+	height: $room-height * 1.6;
+	background-image: linear-gradient(#9e3b10, #50200b);
+
+	position: absolute;
+	perspective: 1.2 * $r;
+
+	> * {
+		position: absolute;
+		width: 100%;
+		height: 100%;
+	}
+
+	.interstice {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+
+		transform: translateZ($offset) rotateX(-90deg);
+		transform-style: preserve-3d;
+
+		> * {
+			transform: translateZ(-$room-height/2);
+			position: absolute;
+		}
+
+		$k: 70.71% 70.71%; // sqrt(2) / 2;
+
+		.ceilingHole {
+			@include circle(35vh);
+			background-image: radial-gradient($k, #391000, #542614 40%, #3e1b0d 100%);
+		}
+
+		.ceilingHoleTrim {
+			@include circle(45vh);
+			background-image: radial-gradient($k, #5e3412 55%, #7a4010 100%);
+		}
+
+		.ceilingMain {
+			@include circle(70vh);
+			background-image: radial-gradient($k, #9f4e04 65%, #c87427 100%);
+		}
+
+		.ceilingTrim {
+			@include circle(90vh);
+			background-image: radial-gradient($k, #d89141 90%, #f5ad5b 100%);
+		}
+
+		.floor {
+			@include circle(90vh);
+			transform: translateZ($room-height/2);
+			background-image: radial-gradient($k, $dark-brown 60%, #402101 100%);
+		}
+	}
+}

--- a/src/layouts/MuseumRoom.tsx
+++ b/src/layouts/MuseumRoom.tsx
@@ -2,6 +2,8 @@ import { PropsWithChildren } from "react";
 
 import { CarouselGallery } from "components";
 
+import styles from "./MuseumRoom.module.scss";
+
 interface MuseumRoomProps extends PropsWithChildren {
 	rotating?: boolean;
 }
@@ -9,7 +11,16 @@ interface MuseumRoomProps extends PropsWithChildren {
 function MuseumRoom({ rotating, children }: MuseumRoomProps) {
 	return (
 		<>
-			<CarouselGallery rotating={rotating || false} />
+			<div className={styles.museumRoom}>
+				<div className={styles.interstice}>
+					<div className={styles.ceilingTrim} />
+					<div className={styles.ceilingMain} />
+					<div className={styles.ceilingHoleTrim} />
+					<div className={styles.ceilingHole} />
+					<div className={styles.floor} />
+				</div>
+				<CarouselGallery rotating={rotating || false} />
+			</div>
 			<div style={{ position: "relative" }}>{children}</div>
 		</>
 	);

--- a/src/layouts/MuseumRoom.tsx
+++ b/src/layouts/MuseumRoom.tsx
@@ -1,0 +1,18 @@
+import { PropsWithChildren } from "react";
+
+import { CarouselGallery } from "components";
+
+interface MuseumRoomProps extends PropsWithChildren {
+	rotating?: boolean;
+}
+
+function MuseumRoom({ rotating, children }: MuseumRoomProps) {
+	return (
+		<>
+			<CarouselGallery rotating={rotating || false} />
+			<div style={{ position: "relative" }}>{children}</div>
+		</>
+	);
+}
+
+export default MuseumRoom;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,4 +1,5 @@
 import type { AppProps } from "next/app";
+import Head from "next/head";
 
 import { Footer, Navigation } from "components";
 import FontProvider from "utils/FontProvider";
@@ -10,6 +11,9 @@ import "styles/hackuci.scss";
 export default function App({ Component, pageProps }: AppProps) {
 	return (
 		<>
+			<Head>
+				<meta name="viewport" content="width=device-width, initial-scale=1" />
+			</Head>
 			<FontProvider />
 			<Navigation />
 			<main>

--- a/src/views/home/Home.tsx
+++ b/src/views/home/Home.tsx
@@ -1,3 +1,5 @@
+import MuseumRoom from "layouts/MuseumRoom";
+
 import Faq from "./sections/Faq/Faq";
 import Landing from "./sections/Landing";
 import Support from "./sections/Support";
@@ -7,11 +9,13 @@ import styles from "./Home.module.scss";
 function Home() {
 	return (
 		<div className={styles.home}>
-			<Landing />
-			<Support />
-			<div className={styles.faqBackground}>
-				<Faq />
-			</div>
+			<MuseumRoom rotating>
+				<Landing />
+				<Support />
+				<div className={styles.faqBackground}>
+					<Faq />
+				</div>
+			</MuseumRoom>
 		</div>
 	);
 }

--- a/src/views/home/sections/Landing.module.scss
+++ b/src/views/home/sections/Landing.module.scss
@@ -1,0 +1,3 @@
+.landing {
+	min-height: 100vh;
+}

--- a/src/views/home/sections/Landing.tsx
+++ b/src/views/home/sections/Landing.tsx
@@ -1,6 +1,8 @@
+import styles from "./Landing.module.scss";
+
 function Landing() {
 	return (
-		<div>
+		<div className={styles.landing}>
 			<h1>HackUCI</h1>
 			<p>Lorem ipsum dolor, sit amet consectetur adipisicing elit.</p>
 		</div>

--- a/src/views/home/sections/Landing.tsx
+++ b/src/views/home/sections/Landing.tsx
@@ -1,11 +1,8 @@
-import { CarouselGallery } from "components";
-
 function Landing() {
 	return (
 		<div>
 			<h1>HackUCI</h1>
 			<p>Lorem ipsum dolor, sit amet consectetur adipisicing elit.</p>
-			<CarouselGallery />
 		</div>
 	);
 }

--- a/src/views/home/sections/Landing.tsx
+++ b/src/views/home/sections/Landing.tsx
@@ -1,8 +1,11 @@
+import { CarouselGallery } from "components";
+
 function Landing() {
 	return (
 		<div>
 			<h1>HackUCI</h1>
 			<p>Lorem ipsum dolor, sit amet consectetur adipisicing elit.</p>
+			<CarouselGallery />
 		</div>
 	);
 }


### PR DESCRIPTION
Implement rotating carousel gallery
- Uses `div` elements until graphics has the paintings ready
- Use native `perspective` effects with 3D transformations
  - Some workarounds are needed for certain versions of Safari and iOS

Create `MuseumRoom` layout with floor and ceiling decorations
- Remove Navbar background color (approved by graphics).
- When expanding collapsed Navbar, the page content will shift content down and expose more of the brown gradient in the ceiling.