### PR TITLE
Implement user identity management and guest authentication

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,4 +5,6 @@ pytest==7.2.0
 pytest-asyncio==0.20.3
 pytest-cov==4.0.0
 
+types-python-jose==3.3.4.1
+
 uvicorn[standard]==0.20.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ fastapi==0.88.0
 httpx==0.23.1
 python-multipart==0.0.5
 python3-saml==1.14.0
+python-jose[cryptography]==3.3.0
 pydantic[email]==1.10.2
 pymongo==4.3.3
 sendgrid==6.9.7

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -1,9 +1,10 @@
 from fastapi import FastAPI
 
-from routers import saml, user
+from routers import guest, saml, user
 
 app = FastAPI()
 
+app.include_router(guest.router, prefix="/guest", tags=["guest"])
 app.include_router(user.router, prefix="/user", tags=["user"])
 app.include_router(saml.router, prefix="/saml", tags=["saml"])
 

--- a/src/api/auth/guest_auth.py
+++ b/src/api/auth/guest_auth.py
@@ -1,0 +1,105 @@
+from datetime import datetime, timedelta, timezone
+from typing import Optional
+from uuid import uuid4
+
+from pydantic import BaseModel, EmailStr
+
+from auth import user_identity
+from auth.user_identity import GuestUser
+from services import mongodb_handler
+from services.mongodb_handler import BaseRecord, Collection
+from utils import email_handler
+
+
+class GuestAuth(BaseModel):
+    iat: datetime
+    exp: datetime
+    key: str
+
+
+class GuestRecord(BaseRecord):
+    guest_auth: GuestAuth
+
+
+async def initiate_guest_login(email: EmailStr) -> Optional[str]:
+    """Generate a login passphrase to be emailed, save the authentication key,
+    and a confirmation token to be saved as a cookie."""
+    if await _get_existing_key(email):
+        # To prevent spammed requests, user must wait until previous key expires
+        return None
+
+    confirmation = _generate_confirmation_token()
+    passphrase = _generate_passphrase()
+    auth_key = _generate_key(confirmation, passphrase)
+
+    uid = user_identity.scoped_uid(email)
+    now = datetime.now(timezone.utc)
+    exp = now + timedelta(minutes=10)
+
+    guest = GuestRecord(
+        uid=uid,
+        guest_auth=GuestAuth(iat=now, exp=exp, key=auth_key),
+    )
+
+    await _save_guest_key(guest)
+    await email_handler.send_guest_login_email(email, passphrase)
+
+    return confirmation
+
+
+async def verify_guest_credentials(
+    email: EmailStr, passphrase: str, confirmation: str
+) -> bool:
+    """Check that passphrase and confirmation are valid for the given user."""
+    key = await _get_existing_key(email)
+    if not key:
+        return False
+
+    # TODO: delete used key
+    return _validate(key, passphrase, confirmation)
+
+
+def acquire_guest_identity(email: EmailStr) -> GuestUser:
+    """Provide a user identity for the given guest."""
+    return GuestUser(email=email)
+
+
+async def _get_existing_key(email: EmailStr) -> Optional[str]:
+    """Retrieve guest authentication key, `None` if expired."""
+    uid = user_identity.scoped_uid(email)
+    record = await mongodb_handler.retrieve_one(
+        Collection.USERS, {"_id": uid}, ["guest_auth"]
+    )
+
+    if not record or "guest_auth" not in record:
+        return None
+
+    auth = GuestAuth.parse_obj(record["guest_auth"])
+    # TODO: check expiration
+    return auth.key
+
+
+async def _save_guest_key(guest: GuestRecord) -> None:
+    """Save guest authentication key to user record."""
+    await mongodb_handler.update(Collection.USERS, {"_id": guest.uid}, guest.dict())
+
+
+def _generate_confirmation_token() -> str:
+    """Generate a confirmation token to use for guest authentication."""
+    return uuid4().hex
+
+
+def _generate_passphrase() -> str:
+    """Generate a secret passphrase to use for guest authentication."""
+    # TODO: add proper passphrase generation
+    return "correct-horse-battery-staple"
+
+
+def _generate_key(confirmation: str, passphrase: str) -> str:
+    """Generate a key from a passphrase and confirmation token."""
+    return confirmation + passphrase
+
+
+def _validate(key: str, passphrase: str, confirmation: str) -> bool:
+    """Validate a passphrase, confirmation token, and authentication key."""
+    return confirmation + passphrase == key

--- a/src/api/auth/user_identity.py
+++ b/src/api/auth/user_identity.py
@@ -60,6 +60,11 @@ def uci_email(email: EmailStr) -> bool:
     return email.endswith("@uci.edu") or email.endswith(".uci.edu")
 
 
+def utc_now() -> datetime:
+    """Return current datetime with proper UTC timezone."""
+    return datetime.now(timezone.utc)
+
+
 def issue_user_identity(user: User, response: Response) -> Response:
     """Issue a user identity as a JWT cookie added to the given response."""
     jwt_token = _generate_jwt_token(user)
@@ -102,7 +107,7 @@ def _decode_user_identity(user_token: Optional[str]) -> Optional[User]:
 
 def _generate_jwt_token(user: User) -> str:
     """Generate a JWT with claims for the given user."""
-    now = datetime.now(timezone.utc)
+    now = utc_now()
 
     claims = JWTClaims(
         iat=now,

--- a/src/api/auth/user_identity.py
+++ b/src/api/auth/user_identity.py
@@ -1,0 +1,131 @@
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Any, Optional
+
+from fastapi import Cookie, HTTPException, Response, status
+from jose import JWTError, jwt
+from pydantic import BaseModel, EmailStr
+
+JWT_ALGORITHM = "HS256"
+JWT_SECRET = os.getenv("JWT_SECRET", "not a good idea")
+
+
+class User(BaseModel):
+    uid: str
+    email: EmailStr
+
+
+class NativeUser(User):
+    ucinetid: str
+    display_name: str
+    affiliations: list[str]
+
+    def __init__(
+        self,
+        *,
+        ucinetid: str,
+        display_name: str,
+        email: EmailStr,
+        affiliations: list[str],
+    ):
+        uid = f"edu.uci.{ucinetid}"
+        super().__init__(
+            uid=uid,
+            ucinetid=ucinetid,
+            display_name=display_name,
+            email=email,
+            affiliations=affiliations,
+        )
+
+
+class GuestUser(User):
+    def __init__(self, *, email: EmailStr):
+        uid = scoped_uid(email)
+        super().__init__(uid=uid, email=email)
+
+
+class JWTClaims(BaseModel):
+    iat: datetime
+    exp: datetime
+    sub: str
+    data: dict[str, Any]
+
+
+def scoped_uid(email: EmailStr) -> str:
+    """Provide a scoped unique identifier based on the email domain."""
+    if uci_email(email):
+        raise ValueError("UCI user should use NativeUser")
+    local, domain = email.split("@")
+    reversed_domains = ".".join(reversed(domain.split(".")))
+    return f"{reversed_domains}.{local}"
+
+
+def uci_email(email: EmailStr) -> bool:
+    """Check whether or not an email address is part of UCI or a subdomain thereof."""
+    return email.endswith("@uci.edu") or email.endswith(".uci.edu")
+
+
+def issue_user_identity(user: User, response: Response) -> Response:
+    """Issue a user identity as a JWT cookie added to the given response."""
+    jwt_token = _generate_jwt_token(user)
+    response.set_cookie(
+        "hackuci_auth", jwt_token, max_age=4000, secure=True, httponly=True
+    )
+    return response
+
+
+def require_user_identity(hackuci_auth: Optional[str] = Cookie(None)) -> User:
+    """Provide the user decoded from the auth cookie.
+    Raise status 401 if valid identity cannot be decoded."""
+    user_identity = _decode_user_identity(hackuci_auth)
+    if not user_identity:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Not authorized")
+
+    return user_identity
+
+
+def use_user_identity(hackuci_auth: Optional[str] = Cookie(None)) -> Optional[User]:
+    """Provide the user decoded from the auth cookie or `None` if invalid."""
+    return _decode_user_identity(hackuci_auth)
+
+
+def _decode_user_identity(user_token: Optional[str]) -> Optional[User]:
+    """Decode a user object from a JWT.
+    Return `None` if the token is empty or invalid."""
+    if not user_token:
+        return None
+
+    try:
+        decoded_token = _decode_jwt(user_token)
+    except ValueError:
+        return None
+
+    if decoded_token.sub.startswith("edu.uci."):
+        return NativeUser(**decoded_token.data)
+    return GuestUser(**decoded_token.data)
+
+
+def _generate_jwt_token(user: User) -> str:
+    """Generate a JWT with claims for the given user."""
+    now = datetime.now(timezone.utc)
+
+    claims = JWTClaims(
+        iat=now,
+        exp=now + timedelta(hours=1),
+        sub=user.uid,
+        data=user.dict(exclude={"uid"}),
+    )
+
+    token = jwt.encode(claims.dict(), JWT_SECRET, algorithm=JWT_ALGORITHM)
+    return token
+
+
+def _decode_jwt(user_token: str) -> JWTClaims:
+    """Decode a JWT into its original claims.
+    Raise `ValueError` if the token is empty or invalid (including expired)."""
+    try:
+        raw_claims = jwt.decode(user_token, JWT_SECRET, algorithms=[JWT_ALGORITHM])
+    except JWTError:
+        raise ValueError
+
+    return JWTClaims.parse_obj(raw_claims)

--- a/src/api/auth/user_identity.py
+++ b/src/api/auth/user_identity.py
@@ -21,12 +21,7 @@ class NativeUser(User):
     affiliations: list[str]
 
     def __init__(
-        self,
-        *,
-        ucinetid: str,
-        display_name: str,
-        email: EmailStr,
-        affiliations: list[str],
+        self, *, ucinetid: str, display_name: str, email: str, affiliations: list[str]
     ):
         uid = f"edu.uci.{ucinetid}"
         super().__init__(
@@ -39,8 +34,8 @@ class NativeUser(User):
 
 
 class GuestUser(User):
-    def __init__(self, *, email: EmailStr):
-        uid = scoped_uid(email)
+    def __init__(self, *, email: str):
+        uid = scoped_uid(EmailStr(email))
         super().__init__(uid=uid, email=email)
 
 

--- a/src/api/routers/guest.py
+++ b/src/api/routers/guest.py
@@ -1,3 +1,4 @@
+from logging import getLogger
 from urllib.parse import urlencode
 
 from fastapi import APIRouter, Cookie, Depends, Form, HTTPException, status
@@ -5,6 +6,8 @@ from fastapi.responses import RedirectResponse
 from pydantic import EmailStr
 
 from auth import guest_auth, user_identity
+
+log = getLogger(__name__)
 
 router = APIRouter()
 
@@ -27,10 +30,12 @@ def guest_email(email: EmailStr = Form()) -> str:
 
 @router.post("/login")
 async def guest_login(email: EmailStr = Depends(guest_email)) -> RedirectResponse:
-    """Generate login token and set cookie with login key"""
+    """Generate login passphrase and set cookie with confirmation token.
+    The initiation will send an email with the passphrase."""
     try:
         confirmation = await guest_auth.initiate_guest_login(email)
-    except RuntimeError:
+    except RuntimeError as err:
+        log.exception("During guest login: %s", err)
         raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR)
 
     if not confirmation:

--- a/src/api/routers/guest.py
+++ b/src/api/routers/guest.py
@@ -1,0 +1,49 @@
+from urllib.parse import urlencode
+
+from fastapi import APIRouter, Cookie, Form, HTTPException, status
+from fastapi.responses import RedirectResponse
+from pydantic import EmailStr
+
+from auth import guest_auth, user_identity
+
+router = APIRouter()
+
+
+@router.post("/login")
+async def guest_login(email: EmailStr = Form()) -> RedirectResponse:
+    """Generate login token and set cookie with login key"""
+    try:
+        confirmation = await guest_auth.initiate_guest_login(email)
+    except RuntimeError:
+        raise HTTPException(status.HTTP_500_INTERNAL_SERVER_ERROR)
+
+    if not confirmation:
+        raise HTTPException(status.HTTP_429_TOO_MANY_REQUESTS)
+
+    # Redirect to guest login page on client
+    # which displays a message to check email and enter passphrase
+    query = urlencode({"email": email})
+    response = RedirectResponse(f"/guest-login?{query}", status.HTTP_303_SEE_OTHER)
+    response.set_cookie(
+        "guest_confirmation", confirmation, max_age=600, secure=True, httponly=True
+    )
+    return response
+
+
+@router.post("/verify")
+async def verify_guest_token(
+    email: EmailStr = Form(),
+    passphrase: str = Form(),
+    guest_confirmation: str = Cookie(),
+) -> RedirectResponse:
+    """Verify guest token"""
+    if not await guest_auth.verify_guest_credentials(
+        email, passphrase, guest_confirmation
+    ):
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Unauthorized")
+
+    guest = guest_auth.acquire_guest_identity(email)
+
+    res = RedirectResponse("/portal", status_code=status.HTTP_303_SEE_OTHER)
+    user_identity.issue_user_identity(guest, res)
+    return res

--- a/src/api/routers/user.py
+++ b/src/api/routers/user.py
@@ -19,15 +19,10 @@ router = APIRouter()
 
 @router.post("/login")
 async def login(email: EmailStr = Form()) -> RedirectResponse:
-    if not email.endswith(".edu"):
-        raise HTTPException(
-            status.HTTP_403_FORBIDDEN, "Only .edu emails are allowed to login"
-        )
-
     if user_identity.uci_email(email):
         # redirect user to UCI SSO login endpoint, changing to GET method
-        return RedirectResponse("/api/saml/login", status_code=303)
-    return RedirectResponse("/api/guest/login", status_code=307)
+        return RedirectResponse("/api/saml/login", status.HTTP_303_SEE_OTHER)
+    return RedirectResponse("/api/guest/login", status.HTTP_307_TEMPORARY_REDIRECT)
 
 
 @router.post("/apply", status_code=status.HTTP_201_CREATED)

--- a/src/api/routers/user.py
+++ b/src/api/routers/user.py
@@ -27,8 +27,7 @@ async def login(email: EmailStr = Form()) -> RedirectResponse:
     if user_identity.uci_email(email):
         # redirect user to UCI SSO login endpoint, changing to GET method
         return RedirectResponse("/api/saml/login", status_code=303)
-    # TODO: add authentication for non-UCI users
-    raise HTTPException(501)
+    return RedirectResponse("/api/guest/login", status_code=307)
 
 
 @router.post("/apply", status_code=status.HTTP_201_CREATED)

--- a/src/api/routers/user.py
+++ b/src/api/routers/user.py
@@ -5,6 +5,7 @@ from fastapi import APIRouter, Depends, Form, HTTPException, UploadFile, status
 from fastapi.responses import RedirectResponse
 from pydantic import EmailStr
 
+from auth import user_identity
 from models.ApplicationData import ProcessedApplicationData, RawApplicationData
 from models.User import User
 from services import mongodb_handler
@@ -16,11 +17,6 @@ log = getLogger(__name__)
 router = APIRouter()
 
 
-def _uci_email(email: str) -> bool:
-    """Checks whether or not an email address is part of UCI or a subdomain thereof"""
-    return email.endswith("@uci.edu") or email.endswith(".uci.edu")
-
-
 @router.post("/login")
 async def login(email: EmailStr = Form()) -> RedirectResponse:
     if not email.endswith(".edu"):
@@ -28,7 +24,7 @@ async def login(email: EmailStr = Form()) -> RedirectResponse:
             status.HTTP_403_FORBIDDEN, "Only .edu emails are allowed to login"
         )
 
-    if _uci_email(email):
+    if user_identity.uci_email(email):
         # redirect user to UCI SSO login endpoint, changing to GET method
         return RedirectResponse("/api/saml/login", status_code=303)
     # TODO: add authentication for non-UCI users

--- a/src/api/services/mongodb_handler.py
+++ b/src/api/services/mongodb_handler.py
@@ -28,6 +28,7 @@ class BaseRecord(BaseModel):
 class Collection(str, Enum):
     USERS = "users"
     TESTING = "testing"
+    SETTINGS = "settings"
 
 
 async def insert(
@@ -45,7 +46,7 @@ async def insert(
 
 async def retrieve_one(
     collection: Collection, query: Mapping[str, object], fields: list[str] = []
-) -> Optional[dict[str, object]]:
+) -> Optional[dict[str, Any]]:
     """Search for and retrieve the specified fields of all documents (if any exist)
     that satisfy the provided query."""
     COLLECTION = DB[collection.value]

--- a/src/api/services/mongodb_handler.py
+++ b/src/api/services/mongodb_handler.py
@@ -1,10 +1,11 @@
 import os
 from enum import Enum
 from logging import getLogger
-from typing import Mapping, Optional, Union
+from typing import Any, Mapping, Optional, Union
 
 from motor.core import AgnosticCollection, AgnosticDatabase
 from motor.motor_asyncio import AsyncIOMotorClient
+from pydantic import BaseModel, Field
 from pymongo.results import InsertOneResult, UpdateResult
 
 log = getLogger(__name__)
@@ -12,6 +13,16 @@ log = getLogger(__name__)
 MONGODB_URI = os.getenv("MONGODB_URI")
 MONGO_CLIENT = AsyncIOMotorClient(MONGODB_URI)
 DB: AgnosticDatabase = MONGO_CLIENT["hackuci"]
+
+
+class BaseRecord(BaseModel):
+    uid: str = Field(alias="_id")
+
+    def dict(self, *args: Any, **kwargs: Any) -> dict[str, Any]:
+        return BaseModel.dict(self, by_alias=True, *args, **kwargs)
+
+    class Config:
+        allow_population_by_field_name = True
 
 
 class Collection(str, Enum):

--- a/src/api/utils/email_handler.py
+++ b/src/api/utils/email_handler.py
@@ -17,6 +17,7 @@ class ContactInfo(Protocol):
 class Template(str, Enum):
     # TODO: provide actual template IDs
     confirmation = "confirmation-template-id"
+    GUEST_TOKEN = "guest-template"
 
 
 async def send_application_confirmation_email(user: ContactInfo) -> None:
@@ -30,4 +31,13 @@ async def send_application_confirmation_email(user: ContactInfo) -> None:
             "first_name": user.first_name,
             "last_name": user.last_name,
         },
+    )
+
+
+async def send_guest_login_email(email: EmailStr, passphrase: str) -> None:
+    """Email login passphrase to guest."""
+    await sendgrid_handler.send_email(
+        Template.GUEST_TOKEN,
+        HACKUCI_SENDER,
+        {"email": email, "passphrase": passphrase},
     )

--- a/src/pages/guest-login.tsx
+++ b/src/pages/guest-login.tsx
@@ -1,0 +1,1 @@
+export { GuestLogin as default } from "views";

--- a/src/views/guest-login/GuestLogin.tsx
+++ b/src/views/guest-login/GuestLogin.tsx
@@ -1,0 +1,17 @@
+import Container from "react-bootstrap/Container";
+
+import VerificationForm from "./components/VerificationForm";
+
+function GuestLogin() {
+	return (
+		<Container>
+			<h1>Log In</h1>
+			<p>
+				A login passphrase was sent to your email. Please enter the passphrase.
+			</p>
+			<VerificationForm />
+		</Container>
+	);
+}
+
+export default GuestLogin;

--- a/src/views/guest-login/components/VerificationForm.tsx
+++ b/src/views/guest-login/components/VerificationForm.tsx
@@ -1,0 +1,37 @@
+import { useRouter } from "next/router";
+
+import Button from "react-bootstrap/Button";
+import Form from "react-bootstrap/Form";
+
+import { ValidatingForm } from "components";
+
+const VERIFICATION_PATH = "/api/guest/verify";
+const PASSPHRASE_REGEX = /\w+-\w+-\w+-\w+/;
+
+function VerificationForm() {
+	const router = useRouter();
+	const { email } = router.query;
+
+	return (
+		<ValidatingForm method="post" action={VERIFICATION_PATH}>
+			<input type="email" name="email" value={email} hidden />
+			<Form.Group controlId="email-input" className="mb-3">
+				<Form.Label>Passphrase</Form.Label>
+				<Form.Control
+					as="input"
+					type="text"
+					pattern={PASSPHRASE_REGEX.source}
+					required
+					name="passphrase"
+					placeholder="Enter passphrase"
+				/>
+				<Form.Control.Feedback type="invalid">
+					Sorry, that passphrase is invalid.
+				</Form.Control.Feedback>
+			</Form.Group>
+			<Button type="submit">Continue</Button>
+		</ValidatingForm>
+	);
+}
+
+export default VerificationForm;

--- a/src/views/index.js
+++ b/src/views/index.js
@@ -1,3 +1,4 @@
 export { default as Dashboard } from "./dashboard/Dashboard";
+export { default as GuestLogin } from "./guest-login/GuestLogin";
 export { default as Home } from "./home/Home";
 export { default as Login } from "./login/Login";

--- a/tests/test_guest.py
+++ b/tests/test_guest.py
@@ -17,6 +17,18 @@ SAMPLE_LOGIN_DATA = {"email": SAMPLE_EMAIL}
 SAMPLE_PASSPHRASE = "correct-horse-battery-staple"
 
 
+def test_non_edu_email_forbidden() -> None:
+    """Test that a guest with a non-edu email is forbidden from logging in."""
+    res = client.post("/login", data={"email": "elon@twitter.com"})
+    assert res.status_code == 403
+
+
+def test_uci_email_forbidden_as_guest() -> None:
+    """Test that a UCI email cannot be used with guest authentication."""
+    res = client.post("/login", data={"email": "hack@uci.edu"})
+    assert res.status_code == 403
+
+
 @patch("utils.email_handler.send_guest_login_email", autospec=True)
 @patch("auth.guest_auth._save_guest_key", autospec=True)
 @patch("auth.guest_auth.datetime", autospec=True)

--- a/tests/test_guest.py
+++ b/tests/test_guest.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, Mock, patch
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from auth import guest_auth
 from auth.guest_auth import GuestAuth, GuestRecord
 from routers import guest
 
@@ -58,7 +59,7 @@ def test_guest_login_initiation(
             guest_auth=GuestAuth(
                 iat=datetime(2023, 2, 4),
                 exp=datetime(2023, 2, 4, 0, 10, 0),
-                key="abcdef" + SAMPLE_PASSPHRASE,
+                key=guest_auth._generate_key("abcdef", SAMPLE_PASSPHRASE),
             ),
         )
     )
@@ -88,7 +89,9 @@ def test_successful_guest_verification_provides_identity(
     mock_get_existing_key: AsyncMock,
 ) -> None:
     """Test a guest successfully verifying guest credentials."""
-    mock_get_existing_key.return_value = "some-confirmation" + SAMPLE_PASSPHRASE
+    mock_get_existing_key.return_value = guest_auth._generate_key(
+        "some-confirmation", SAMPLE_PASSPHRASE
+    )
 
     res = client.post(
         "/verify",

--- a/tests/test_guest.py
+++ b/tests/test_guest.py
@@ -1,0 +1,105 @@
+from datetime import datetime
+from unittest.mock import AsyncMock, Mock, patch
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from auth.guest_auth import GuestAuth, GuestRecord
+from routers import guest
+
+app = FastAPI()
+app.include_router(guest.router)
+
+client = TestClient(app)
+
+SAMPLE_EMAIL = "beaver@caltech.edu"
+SAMPLE_LOGIN_DATA = {"email": SAMPLE_EMAIL}
+SAMPLE_PASSPHRASE = "correct-horse-battery-staple"
+
+
+@patch("utils.email_handler.send_guest_login_email", autospec=True)
+@patch("auth.guest_auth._save_guest_key", autospec=True)
+@patch("auth.guest_auth.datetime", autospec=True)
+@patch("auth.guest_auth._generate_passphrase", autospec=True)
+@patch("auth.guest_auth._generate_confirmation_token", autospec=True)
+@patch("auth.guest_auth._get_existing_key", autospec=True)
+def test_guest_login_initiation(
+    mock_get_existing_key: AsyncMock,
+    mock_generate_confirmation_token: Mock,
+    mock_generate_passphrase: Mock,
+    mock_datetime: Mock,
+    mock_save_guest_key: AsyncMock,
+    mock_send_guest_login_email: AsyncMock,
+) -> None:
+    """Test full guest login initiation flow."""
+
+    mock_get_existing_key.return_value = None
+    mock_generate_confirmation_token.return_value = "abcdef"
+    mock_generate_passphrase.return_value = SAMPLE_PASSPHRASE
+    mock_datetime.now.return_value = datetime(2023, 2, 4)
+
+    res = client.post("/login", data=SAMPLE_LOGIN_DATA, follow_redirects=False)
+
+    mock_save_guest_key.assert_awaited_once_with(
+        GuestRecord(
+            uid="edu.caltech.beaver",
+            guest_auth=GuestAuth(
+                iat=datetime(2023, 2, 4),
+                exp=datetime(2023, 2, 4, 0, 10, 0),
+                key="abcdef" + SAMPLE_PASSPHRASE,
+            ),
+        )
+    )
+    mock_send_guest_login_email.assert_awaited_once_with(
+        SAMPLE_EMAIL, SAMPLE_PASSPHRASE
+    )
+
+    assert res.status_code == 303
+    assert res.headers["location"] == "/guest-login?email=beaver%40caltech.edu"
+    assert res.headers["Set-Cookie"].startswith("guest_confirmation=abcdef;")
+
+
+@patch("auth.guest_auth._get_existing_key", autospec=True)
+def test_requesting_login_when_previous_key_exists_causes_429(
+    mock_get_existing_key: AsyncMock,
+) -> None:
+    """Test that requesting to log in as guest when the user has an existing,
+    unexpired key causes status 429."""
+
+    mock_get_existing_key.return_value = "some-existing-key"
+    res = client.post("/login", data=SAMPLE_LOGIN_DATA)
+    assert res.status_code == 429
+
+
+@patch("auth.guest_auth._get_existing_key", autospec=True)
+def test_successful_guest_verification_provides_identity(
+    mock_get_existing_key: AsyncMock,
+) -> None:
+    """Test a guest successfully verifying guest credentials."""
+    mock_get_existing_key.return_value = "some-confirmation" + SAMPLE_PASSPHRASE
+
+    res = client.post(
+        "/verify",
+        data={"email": SAMPLE_EMAIL, "passphrase": SAMPLE_PASSPHRASE},
+        cookies={"guest_confirmation": "some-confirmation"},
+        follow_redirects=False,
+    )
+
+    assert res.status_code == 303
+    assert res.headers["Set-Cookie"].startswith("hackuci_auth=")
+
+
+@patch("auth.guest_auth._get_existing_key", autospec=True)
+def test_invalid_guest_verification_is_unauthorized(
+    mock_get_existing_key: AsyncMock,
+) -> None:
+    """Test that a guest with invalid credentials is unauthorized."""
+    mock_get_existing_key.return_value = "some-existing-key"
+
+    res = client.post(
+        "/verify",
+        data={"email": SAMPLE_EMAIL, "passphrase": "bad-passphrase"},
+        cookies={"guest_confirmation": "not-a-confirmation"},
+    )
+
+    assert res.status_code == 401

--- a/tests/test_guest.py
+++ b/tests/test_guest.py
@@ -32,7 +32,7 @@ def test_uci_email_forbidden_as_guest() -> None:
 
 @patch("utils.email_handler.send_guest_login_email", autospec=True)
 @patch("auth.guest_auth._save_guest_key", autospec=True)
-@patch("auth.guest_auth.datetime", autospec=True)
+@patch("auth.guest_auth.utc_now", autospec=True)
 @patch("auth.guest_auth._generate_passphrase", autospec=True)
 @patch("auth.guest_auth._generate_confirmation_token", autospec=True)
 @patch("auth.guest_auth._get_existing_key", autospec=True)
@@ -40,7 +40,7 @@ def test_guest_login_initiation(
     mock_get_existing_key: AsyncMock,
     mock_generate_confirmation_token: Mock,
     mock_generate_passphrase: Mock,
-    mock_datetime: Mock,
+    mock_utc_now: Mock,
     mock_save_guest_key: AsyncMock,
     mock_send_guest_login_email: AsyncMock,
 ) -> None:
@@ -49,7 +49,7 @@ def test_guest_login_initiation(
     mock_get_existing_key.return_value = None
     mock_generate_confirmation_token.return_value = "abcdef"
     mock_generate_passphrase.return_value = SAMPLE_PASSPHRASE
-    mock_datetime.now.return_value = datetime(2023, 2, 4)
+    mock_utc_now.return_value = datetime(2023, 2, 4)
 
     res = client.post("/login", data=SAMPLE_LOGIN_DATA, follow_redirects=False)
 

--- a/tests/test_guest_auth.py
+++ b/tests/test_guest_auth.py
@@ -1,0 +1,43 @@
+from datetime import datetime
+from unittest.mock import AsyncMock, patch
+
+from pydantic import EmailStr
+
+from auth import guest_auth
+
+SAMPLE_EMAIL = EmailStr("jeff@amazon.com")
+
+
+@patch("services.mongodb_handler.retrieve_one", autospec=True)
+async def test_get_existing_unexpired_key(mock_mongodb_retrieve_one: AsyncMock) -> None:
+    """Test that existing, unexpired guest authorization key can be retrieved."""
+    iat = datetime(2023, 1, 11)
+    exp = datetime(2023, 12, 31)
+    mock_mongodb_retrieve_one.return_value = {
+        "guest_auth": {"iat": iat, "exp": exp, "key": "some-key"}
+    }
+
+    key = await guest_auth._get_existing_key(SAMPLE_EMAIL)
+    assert key == "some-key"
+
+
+@patch("services.mongodb_handler.retrieve_one", autospec=True)
+async def test_get_nonexisting_key(mock_mongodb_retrieve_one: AsyncMock) -> None:
+    """Test that nonexistent guest authorization key is returned as None."""
+    mock_mongodb_retrieve_one.return_value = None
+
+    key = await guest_auth._get_existing_key(SAMPLE_EMAIL)
+    assert key is None
+
+
+@patch("services.mongodb_handler.retrieve_one", autospec=True)
+async def test_guest_credentials_invalid_when_no_key(
+    mock_mongodb_retrieve_one: AsyncMock,
+) -> None:
+    """Test that guest credentials are invalid when there is no saved auth key."""
+    mock_mongodb_retrieve_one.return_value = None
+
+    verification = await guest_auth.verify_guest_credentials(
+        SAMPLE_EMAIL, "some-passphrase", "some-confirmation"
+    )
+    assert verification is False

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,4 +1,4 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, status
 from fastapi.testclient import TestClient
 
 from routers import user
@@ -12,5 +12,14 @@ client = TestClient(app)
 def test_login_as_uci_redirects_to_saml() -> None:
     """Tests that logging in with UCI email redirects to SAML for UCI SSO"""
     res = client.post("/login", data={"email": "hack@uci.edu"}, follow_redirects=False)
-    assert res.status_code == 303
+    assert res.status_code == status.HTTP_303_SEE_OTHER
     assert res.headers["location"] == "/api/saml/login"
+
+
+def test_login_as_non_uci_redirects_to_guest_login() -> None:
+    """Test that logging in with a non-UCI email redirects to guest login endpoint."""
+    res = client.post(
+        "/login", data={"email": "jeff@amazon.com"}, follow_redirects=False
+    )
+    assert res.status_code == status.HTTP_307_TEMPORARY_REDIRECT
+    assert res.headers["location"] == "/api/guest/login"

--- a/tests/test_user_identity.py
+++ b/tests/test_user_identity.py
@@ -1,0 +1,77 @@
+from datetime import datetime
+from unittest.mock import Mock, patch
+
+import pytest
+from jose import JWTError
+
+from auth import user_identity
+from auth.user_identity import GuestUser, NativeUser
+
+
+def test_can_encode_and_decode_native_user() -> None:
+    """Test that a `NativeUser` can be encoded and decoded via JWT."""
+    ucinetid = "hack"
+    display_name = "Hack at UCI"
+    email = "hack@uci.edu"
+    affiliations = ["group"]
+
+    user = NativeUser(
+        ucinetid=ucinetid,
+        display_name=display_name,
+        email=email,
+        affiliations=affiliations,
+    )
+
+    jwt_token = user_identity._generate_jwt_token(user)
+    decoded_user = user_identity._decode_user_identity(jwt_token)
+
+    assert decoded_user == user
+
+
+def test_can_encode_and_decode_guest_user() -> None:
+    """Test that a `GuestUser` can be encoded and decoded via JWT."""
+    user = GuestUser(
+        email="hackuci@gmail.com",
+    )
+
+    jwt_token = user_identity._generate_jwt_token(user)
+    decoded_user = user_identity._decode_user_identity(jwt_token)
+
+    assert decoded_user == user
+
+
+def test_empty_identity_with_empty_token() -> None:
+    """Test that no identity is decoded from an empty token."""
+    user = user_identity._decode_user_identity(None)
+    assert user is None
+
+
+def test_error_on_invalid_token() -> None:
+    """Test that decoding an invalid token raises an exception."""
+    with pytest.raises(ValueError):
+        user_identity._decode_jwt("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.e30.secret")
+
+
+@patch("auth.user_identity.datetime", autospec=True)
+def test_error_on_expired_token(mock_datetime: Mock) -> None:
+    """Test that decoding an expired token will cause a ValueError."""
+    # mock token creation time
+    mock_datetime.now.return_value = datetime(2014, 5, 23)
+
+    user = GuestUser(email="hackuci@gmail.com")
+    jwt_token = user_identity._generate_jwt_token(user)
+
+    mock_datetime.now.assert_called_once()
+    with pytest.raises(ValueError):
+        user_identity._decode_jwt(jwt_token)
+
+
+@patch("jose.jwt.decode", autospec=True)
+def test_jwt_error_causes_empty_identity(mock_jwt_decode: Mock) -> None:
+    """Test that decoding an expired token will cause a ValueError."""
+    user = GuestUser(email="hackuci@gmail.com")
+    mock_jwt_decode.side_effect = JWTError
+
+    jwt_token = user_identity._generate_jwt_token(user)
+    decoded_user = user_identity._decode_user_identity(jwt_token)
+    assert decoded_user is None


### PR DESCRIPTION
## Changes
Implement user identities with JWT
- Create `NativeUser` and `GuestUser` user identities
- Provide JWT after SAML authentication

Implement guest authentication
- Generate a login passphrase to be emailed to the user
- Generate a confirmation token to be saved as a cookie in the browser
- Save an authentication key which can verify the passphrase and token
- Incorporate passphrase word list from database
- When checking for an existing guest authenication key, remove the key if it is expired
- After validaiting guest credentials, remove the authentication key

## Notes
Guest authentication is restricted to `.edu` emails. There may be mentors and volunteers who need exceptions, and we will eventually need a separate system to authenticate sponsors.

We will eventually need to modify the application endpoint to use user identity instead of email.