### PR TITLE
Add tab titles to views

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -10,7 +10,7 @@ const devConfig = {
 		return [
 			{
 				source: "/api/:path*",
-				destination: "http://localhost:8000/:path*",
+				destination: "http://127.0.0.1:8000/:path*",
 			},
 		];
 	},

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -44,6 +44,7 @@ AppProps) {
 	return (
 		<>
 			<Head>
+				<title>HackUCI 2023</title>
 				<meta name="viewport" content="width=device-width, initial-scale=1" />
 			</Head>
 			<FontProvider />

--- a/src/views/apply/Apply.tsx
+++ b/src/views/apply/Apply.tsx
@@ -1,10 +1,13 @@
 import Head from "next/head";
 import { useContext, useEffect, useState } from "react";
 import { Container } from "react-bootstrap";
+
 import UserContext from "utils/userContext";
-import styles from "./Apply.module.scss";
+
 import ApplicationForm from "./components/ApplicationForm";
 import ApplicationPreface from "./components/ApplicationPreface";
+
+import styles from "./Apply.module.scss";
 
 function Apply() {
 	const { uid, status } = useContext(UserContext);

--- a/src/views/apply/Apply.tsx
+++ b/src/views/apply/Apply.tsx
@@ -1,3 +1,4 @@
+import Head from "next/head";
 import { useContext, useEffect, useState } from "react";
 import { Container } from "react-bootstrap";
 import UserContext from "utils/userContext";
@@ -26,6 +27,9 @@ function Apply() {
 
 	return (
 		<div className={styles.main}>
+			<Head>
+				<title>Apply | HackUCI 2023</title>
+			</Head>
 			<Container className={styles.apply}>
 				{!acceptedPreface ? (
 					<ApplicationPreface

--- a/src/views/login/Login.tsx
+++ b/src/views/login/Login.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 import Container from "react-bootstrap/Container";
 
 import MuseumRoom from "layouts/MuseumRoom";
+import Head from "next/head";
 import LoginForm from "./components/LoginForm";
 import styles from "./Login.module.scss";
 
@@ -12,6 +13,9 @@ function Login() {
 
 	return (
 		<MuseumRoom>
+			<Head>
+				<title>Login | HackUCI 2023</title>
+			</Head>
 			<section className={styles.login}>
 				<Container className={styles.container}>
 					<h1>Log In</h1>

--- a/src/views/login/Login.tsx
+++ b/src/views/login/Login.tsx
@@ -1,9 +1,11 @@
+import Head from "next/head";
 import { useEffect } from "react";
 import Container from "react-bootstrap/Container";
 
 import MuseumRoom from "layouts/MuseumRoom";
-import Head from "next/head";
+
 import LoginForm from "./components/LoginForm";
+
 import styles from "./Login.module.scss";
 
 function Login() {

--- a/src/views/portal/Portal.tsx
+++ b/src/views/portal/Portal.tsx
@@ -1,3 +1,4 @@
+import Head from "next/head";
 import Router from "next/router";
 import { useContext, useEffect } from "react";
 import UserContext from "utils/userContext";
@@ -20,6 +21,9 @@ function Portal() {
 
 	return (
 		<div className={styles.portal}>
+			<Head>
+				<title>Application Portal | HackUCI 2023</title>
+			</Head>
 			<h2>Application Portal</h2>
 			<div className={styles.content}>
 				<VerticleTimeline status="submitted" date_submitted="1/11/23" />

--- a/src/views/portal/Portal.tsx
+++ b/src/views/portal/Portal.tsx
@@ -1,9 +1,11 @@
 import Head from "next/head";
 import Router from "next/router";
 import { useContext, useEffect } from "react";
+
 import UserContext from "utils/userContext";
 
 import VerticleTimeline from "./components/VerticleTimeline/VerticleTimeline";
+
 import styles from "./Portal.module.scss";
 
 function Portal() {


### PR DESCRIPTION
- Use `Head` from `next/head` to create `<title></title>` text
    - It is dynamic: if you are on the apply page, for example, the `<title>` will be `Apply | HackUCI 2023`
- I don't know if anyone else had this issue, but I had to change `localhost` to `127.0.0.1` in `next.config.js` in order for `npm run dev` to work correctly. Otherwise, I see `ECONNREFUSED ::1:8000`.