### PR TITLE
Add production job to deployment workflow

### DIFF
--- a/.github/workflows/deploy-main.yml
+++ b/.github/workflows/deploy-main.yml
@@ -3,13 +3,48 @@ env:
   VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
   VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
 on:
-  push:
+  workflow_run:
+    workflows:
+      - Run Checks
+    types:
+      - completed
     branches:
       - main
 
 jobs:
-  build-project:
-    name: Build Project
+  on-checks-failure:
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    steps:
+      - run: echo 'Not deploying since checks failed.'
+
+  deploy-staging:
+    name: Deploy to staging environment
+    runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v3
+
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: "npm"
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@latest
+
+      - name: Deploy to Vercel
+        run: vercel deploy --token=${{ secrets.VERCEL_TOKEN }} > domain.txt
+
+      - name: Apply staging domain.txt
+        run: vercel alias set `cat domain.txt` staging.hackuci.com --token=${{ secrets.VERCEL_TOKEN }}
+
+  deploy-production:
+    name: Deploy to production environment
+    needs: deploy-staging
+    environment: production
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
@@ -21,33 +56,8 @@ jobs:
           node-version: 16
           cache: "npm"
 
-      - name: Cache node_modules
-        id: cache-node-modules
-        uses: actions/cache@v3
-        with:
-          path: ${{ github.workspace }}/node_modules
-          key: ${{ runner.os }}-node-modules-${{ hashFiles('package-lock.json') }}
-
-      - name: Install frontend dependencies
-        if: steps.cache-node-modules.outputs.cache-hit != 'true'
-        run: npm ci
-
-      - name: Cache Next.js build
-        uses: actions/cache@v3
-        with:
-          path: ${{ github.workspace }}/.next/cache
-          # Generate a new cache whenever packages or source files change.
-          key: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}-${{ hashFiles('**.[jt]s', '**.[jt]sx') }}
-          # If source files changed but packages didn't, rebuild from a prior cache.
-          restore-keys: ${{ runner.os }}-nextjs-${{ hashFiles('**/package-lock.json') }}
-
       - name: Install Vercel CLI
         run: npm install --global vercel@latest
 
       - name: Deploy to Vercel
-        run: vercel deploy --token=${{ secrets.VERCEL_TOKEN }} > domain.txt
-
-      - name: Apply staging domain.txt
-        run: vercel alias set `cat domain.txt` staging.hackuci.com --token=${{ secrets.VERCEL_TOKEN }}
-
-      # TODO: promotion
+        run: vercel deploy --prod --token=${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
To allow deploying `main` to production with approval,
- Make deployment workflow depend on success of Run Checks
- Add production deployment job which needs successful staging run

We may eventually consider building the project from the workflow since currently it just waits for Vercel to run the build.