### PR TITLE
Add links to Devpost

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -23,12 +23,23 @@ const REWRITES = [
 	},
 ];
 
+const REDIRECTS = [
+	{
+		source: "/devpost",
+		destination: "https://hack-at-uci-2023.devpost.com",
+		permanent: true,
+	},
+];
+
 /** @type {import('next').NextConfig} */
 const nextConfig = {
 	...baseConfig,
 	swcMinify: false,
 	async rewrites() {
 		return REWRITES;
+	},
+	async redirects() {
+		return REDIRECTS;
 	},
 };
 
@@ -42,6 +53,9 @@ const devConfig = {
 				destination: "http://127.0.0.1:8000/:path*",
 			},
 		]);
+	},
+	async redirects() {
+		return REDIRECTS;
 	},
 };
 

--- a/next.config.js
+++ b/next.config.js
@@ -13,7 +13,7 @@ const REWRITES = [
 		source: "/volunteer",
 		destination: "https://forms.gle/bLw9nHffqoz4kAGR7",
 	},
-  {
+	{
 		source: "/report",
 		destination: "https://forms.gle/yM8Revi2NLHGNKs17",
 	},

--- a/src/components/Navigation/Navigation.tsx
+++ b/src/components/Navigation/Navigation.tsx
@@ -54,6 +54,9 @@ function Navigation() {
 							Admin
 						</PrivateNavLinkItem>
 						<NavLinkItem href="/resources">Resources</NavLinkItem>
+						<NavLinkItem href="https://hack-at-uci-2023.devpost.com/">
+							Devpost
+						</NavLinkItem>
 						<NavLinkItem href="/report">Report Incident</NavLinkItem>
 						<NavLinkItem
 							href={logButtonPath}

--- a/src/views/schedule/Schedule.module.scss
+++ b/src/views/schedule/Schedule.module.scss
@@ -17,3 +17,12 @@
 	text-align: center;
 	color: white;
 }
+
+.link {
+	color: white;
+	transition: 0.25s ease;
+
+	&:hover {
+		color: #ccc;
+	}
+}

--- a/src/views/schedule/Schedule.tsx
+++ b/src/views/schedule/Schedule.tsx
@@ -45,7 +45,17 @@ function Schedule() {
 						<Countdown date={devpostSubmission} />
 					</div>
 					<div className="lead my-2">
-						<span> Until Devpost Submission Closes</span>
+						<span>
+							{" "}
+							Until{" "}
+							<a
+								href="https://hack-at-uci-2023.devpost.com/"
+								className={styles.link}
+							>
+								Devpost
+							</a>{" "}
+							Submission Closes
+						</span>
 					</div>
 				</section>
 			);


### PR DESCRIPTION
- For some reason, setting up a rewrite redirecting `/devpost` to the Devpost fails, as one is only shown a page that says "Page does not exist".
- Directly added the Devpost link to the navbar and the schedule page.